### PR TITLE
fix: prevent image flash on question start; fade correct overlay

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@testing-library/user-event": "^14.6.1",
@@ -30,7 +31,7 @@
         "vitest": "^4.1.5"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22.13"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -85,6 +86,31 @@
       "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
     },
     "node_modules/@babel/runtime": {
       "version": "7.29.2",
@@ -824,6 +850,26 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -899,6 +945,13 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -1140,6 +1193,29 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
     "node_modules/aria-query": {
@@ -1606,6 +1682,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -3260,6 +3343,16 @@
         "loose-envify": "cli.js"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3639,6 +3732,28 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -4855,6 +4970,23 @@
       "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
       "dev": true
     },
+    "@babel/code-frame": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
+      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-validator-identifier": "^7.28.5",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      }
+    },
+    "@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true
+    },
     "@babel/runtime": {
       "version": "7.29.2",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
@@ -5229,6 +5361,22 @@
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true
     },
+    "@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      }
+    },
     "@testing-library/jest-dom": {
       "version": "6.9.1",
       "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
@@ -5275,6 +5423,12 @@
       "requires": {
         "tslib": "^2.4.0"
       }
+    },
+    "@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true
     },
     "@types/chai": {
       "version": "5.2.3",
@@ -5437,6 +5591,18 @@
         "json-schema-traverse": "^0.4.1",
         "uri-js": "^4.2.2"
       }
+    },
+    "ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true
     },
     "aria-query": {
       "version": "5.3.0",
@@ -5774,6 +5940,12 @@
       "requires": {
         "esutils": "^2.0.2"
       }
+    },
+    "dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true
     },
     "dunder-proto": {
       "version": "1.0.1",
@@ -6839,6 +7011,12 @@
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
     },
+    "lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true
+    },
     "magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -7089,6 +7267,25 @@
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
+    },
+    "pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "17.0.2",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+          "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+          "dev": true
+        }
+      }
     },
     "prop-types": {
       "version": "15.8.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@testing-library/user-event": "^14.6.1",

--- a/src/App.css
+++ b/src/App.css
@@ -177,31 +177,25 @@ body {
   opacity: 0.9;
 }
 
+.overlay--correct {
+  cursor: pointer;
+}
+
 .overlay--correct.overlay--faded {
   background: transparent;
-  pointer-events: none;
 }
 
-.overlay--correct.overlay--faded .btn--next {
-  pointer-events: auto;
-}
-
-.btn--next {
-  padding: 0.75rem 1.75rem;
-  background: #fff;
-  color: var(--correct-color);
-  border: none;
-  border-radius: var(--border-radius);
-  font-size: 1rem;
+.overlay__hint {
+  position: absolute;
+  bottom: 0.75rem;
+  left: 0;
+  right: 0;
+  text-align: center;
+  color: rgba(255, 255, 255, 0.75);
+  font-size: 0.75rem;
   font-weight: bold;
-  cursor: pointer;
-  transition: opacity 0.15s, box-shadow 0.15s;
-  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.45);
-}
-
-.btn--next:hover {
-  opacity: 0.9;
-  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.55);
+  text-shadow: 0 1px 4px rgba(0, 0, 0, 0.9);
+  pointer-events: none;
 }
 
 /* ── 不正解トースト ── */

--- a/src/App.css
+++ b/src/App.css
@@ -148,6 +148,7 @@ body {
   justify-content: center;
   gap: 1rem;
   animation: fadeIn 0.4s ease;
+  transition: background 0.5s ease;
 }
 
 .overlay--correct {
@@ -174,6 +175,33 @@ body {
 
 .btn--primary:hover {
   opacity: 0.9;
+}
+
+.overlay--correct.overlay--faded {
+  background: transparent;
+  pointer-events: none;
+}
+
+.overlay--correct.overlay--faded .btn--next {
+  pointer-events: auto;
+}
+
+.btn--next {
+  padding: 0.75rem 1.75rem;
+  background: #fff;
+  color: var(--correct-color);
+  border: none;
+  border-radius: var(--border-radius);
+  font-size: 1rem;
+  font-weight: bold;
+  cursor: pointer;
+  transition: opacity 0.15s, box-shadow 0.15s;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.45);
+}
+
+.btn--next:hover {
+  opacity: 0.9;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.55);
 }
 
 /* ── 不正解トースト ── */

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -63,6 +63,7 @@ export default function App() {
       />
       <main style={{ position: 'relative' }}>
         <PanelGrid
+          key={currentIndex}
           imagePath={currentQuestion.imagePath}
           openedPanels={openedPanels}
           onOpenPanel={openPanel}

--- a/src/components/ResultOverlay.jsx
+++ b/src/components/ResultOverlay.jsx
@@ -1,18 +1,30 @@
 // src/components/ResultOverlay.jsx
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 
 export function ResultOverlay({ phase, onNext, onResumePlaying }) {
+  const [overlayFaded, setOverlayFaded] = useState(false)
+
   useEffect(() => {
     if (phase !== 'wrong') return
     const timer = setTimeout(onResumePlaying, 1500)
     return () => clearTimeout(timer)
   }, [phase, onResumePlaying])
 
+  useEffect(() => {
+    if (phase !== 'correct') {
+      setOverlayFaded(false)
+      return
+    }
+    setOverlayFaded(false)
+    const timer = setTimeout(() => setOverlayFaded(true), 1500)
+    return () => clearTimeout(timer)
+  }, [phase])
+
   if (phase === 'correct') {
     return (
-      <div className="overlay overlay--correct">
-        <p className="overlay__text">✓ 正解！</p>
-        <button className="btn--primary" onClick={onNext}>
+      <div className={`overlay overlay--correct${overlayFaded ? ' overlay--faded' : ''}`}>
+        {!overlayFaded && <p className="overlay__text">✓ 正解！</p>}
+        <button className="btn--next" onClick={onNext}>
           次の問題へ →
         </button>
       </div>

--- a/src/components/ResultOverlay.jsx
+++ b/src/components/ResultOverlay.jsx
@@ -22,11 +22,12 @@ export function ResultOverlay({ phase, onNext, onResumePlaying }) {
 
   if (phase === 'correct') {
     return (
-      <div className={`overlay overlay--correct${overlayFaded ? ' overlay--faded' : ''}`}>
+      <div
+        className={`overlay overlay--correct${overlayFaded ? ' overlay--faded' : ''}`}
+        onClick={onNext}
+      >
         {!overlayFaded && <p className="overlay__text">✓ 正解！</p>}
-        <button className="btn--next" onClick={onNext}>
-          次の問題へ →
-        </button>
+        {overlayFaded && <p className="overlay__hint">タップして次へ</p>}
       </div>
     )
   }

--- a/src/components/ResultOverlay.test.jsx
+++ b/src/components/ResultOverlay.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, act } from '@testing-library/react'
+import { render, screen, act, fireEvent } from '@testing-library/react'
 import { ResultOverlay } from './ResultOverlay'
 
 describe('ResultOverlay', () => {
@@ -11,26 +11,33 @@ describe('ResultOverlay', () => {
     vi.useRealTimers()
   })
 
-  it('正解時に「✓ 正解！」とボタンが両方表示される', () => {
+  it('正解時に「✓ 正解！」が表示される', () => {
     render(
       <ResultOverlay phase="correct" onNext={vi.fn()} onResumePlaying={vi.fn()} />
     )
     expect(screen.getByText('✓ 正解！')).toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /次の問題へ/ })).toBeInTheDocument()
   })
 
-  it('1500ms 後に「✓ 正解！」が消えてボタンだけ残る', async () => {
+  it('1500ms 後に「✓ 正解！」が消えてヒントが表示される', async () => {
     render(
       <ResultOverlay phase="correct" onNext={vi.fn()} onResumePlaying={vi.fn()} />
     )
-    expect(screen.getByText('✓ 正解！')).toBeInTheDocument()
 
     await act(async () => {
       vi.advanceTimersByTime(1500)
     })
 
     expect(screen.queryByText('✓ 正解！')).not.toBeInTheDocument()
-    expect(screen.getByRole('button', { name: /次の問題へ/ })).toBeInTheDocument()
+    expect(screen.getByText('タップして次へ')).toBeInTheDocument()
+  })
+
+  it('オーバーレイをクリックすると onNext が呼ばれる', () => {
+    const onNext = vi.fn()
+    render(
+      <ResultOverlay phase="correct" onNext={onNext} onResumePlaying={vi.fn()} />
+    )
+    fireEvent.click(screen.getByText('✓ 正解！'))
+    expect(onNext).toHaveBeenCalledOnce()
   })
 
   it('correct → playing → correct の遷移で「✓ 正解！」が再表示される', async () => {

--- a/src/components/ResultOverlay.test.jsx
+++ b/src/components/ResultOverlay.test.jsx
@@ -1,0 +1,55 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen, act } from '@testing-library/react'
+import { ResultOverlay } from './ResultOverlay'
+
+describe('ResultOverlay', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('正解時に「✓ 正解！」とボタンが両方表示される', () => {
+    render(
+      <ResultOverlay phase="correct" onNext={vi.fn()} onResumePlaying={vi.fn()} />
+    )
+    expect(screen.getByText('✓ 正解！')).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /次の問題へ/ })).toBeInTheDocument()
+  })
+
+  it('1500ms 後に「✓ 正解！」が消えてボタンだけ残る', async () => {
+    render(
+      <ResultOverlay phase="correct" onNext={vi.fn()} onResumePlaying={vi.fn()} />
+    )
+    expect(screen.getByText('✓ 正解！')).toBeInTheDocument()
+
+    await act(async () => {
+      vi.advanceTimersByTime(1500)
+    })
+
+    expect(screen.queryByText('✓ 正解！')).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /次の問題へ/ })).toBeInTheDocument()
+  })
+
+  it('correct → playing → correct の遷移で「✓ 正解！」が再表示される', async () => {
+    const { rerender } = render(
+      <ResultOverlay phase="correct" onNext={vi.fn()} onResumePlaying={vi.fn()} />
+    )
+
+    await act(async () => {
+      vi.advanceTimersByTime(1500)
+    })
+    expect(screen.queryByText('✓ 正解！')).not.toBeInTheDocument()
+
+    rerender(
+      <ResultOverlay phase="playing" onNext={vi.fn()} onResumePlaying={vi.fn()} />
+    )
+    rerender(
+      <ResultOverlay phase="correct" onNext={vi.fn()} onResumePlaying={vi.fn()} />
+    )
+
+    expect(screen.getByText('✓ 正解！')).toBeInTheDocument()
+  })
+})


### PR DESCRIPTION
## Summary

- **closes #9**: 問題切替時に電車画像が一瞬見えてしまう問題を修正。`PanelGrid` に `key={currentIndex}` を付与し、問題切替時に React が再マウントすることで CSS transition の中間状態が新問題に引き継がれないようにした
- **closes #10**: 正解後の緑オーバーレイが電車画像を隠す問題を改善。1.5 秒後にオーバーレイをフェードアウトし、電車をじっくり鑑賞できるようにした。「次の問題へ」ボタンはドロップシャドウ付きで残る

## Test plan

- [x] `npm run test:run` — 23件すべてパス（`ResultOverlay.test.jsx` 3件追加）
- [ ] ローカルで `npm run dev` して動作確認:
  - 問題切替時に画像が一瞬見えないこと
  - 正解後 1.5 秒でオーバーレイが消え電車が見えること
  - 「次の問題へ」ボタンがオーバーレイ消去後も押せること