### PR TITLE
chore: add eslint config and lint script

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,47 @@
+import js from '@eslint/js'
+import globals from 'globals'
+import reactHooks from 'eslint-plugin-react-hooks'
+import reactRefresh from 'eslint-plugin-react-refresh'
+
+const vitestGlobals = {
+  describe: 'readonly',
+  it: 'readonly',
+  test: 'readonly',
+  expect: 'readonly',
+  vi: 'readonly',
+  beforeEach: 'readonly',
+  afterEach: 'readonly',
+  beforeAll: 'readonly',
+  afterAll: 'readonly',
+}
+
+export default [
+  { ignores: ['dist'] },
+  {
+    files: ['**/*.{js,jsx}'],
+    languageOptions: {
+      ecmaVersion: 2020,
+      globals: globals.browser,
+      parserOptions: {
+        ecmaVersion: 'latest',
+        ecmaFeatures: { jsx: true },
+        sourceType: 'module',
+      },
+    },
+    plugins: {
+      'react-hooks': reactHooks,
+      'react-refresh': reactRefresh,
+    },
+    rules: {
+      ...js.configs.recommended.rules,
+      ...reactHooks.configs.recommended.rules,
+      'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
+    },
+  },
+  {
+    files: ['**/*.test.{js,jsx}', 'src/test/**/*.{js,jsx}'],
+    languageOptions: {
+      globals: vitestGlobals,
+    },
+  },
+]

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
+    "lint": "eslint src",
     "test": "vitest",
     "test:run": "vitest run"
   },

--- a/src/components/Choices.test.jsx
+++ b/src/components/Choices.test.jsx
@@ -1,6 +1,6 @@
 // @vitest-environment node
 // src/components/Choices.test.jsx
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect } from 'vitest'
 import React from 'react'
 import { renderToString } from 'react-dom/server'
 import { Choices } from './Choices'

--- a/src/components/FinalScore.test.jsx
+++ b/src/components/FinalScore.test.jsx
@@ -1,6 +1,6 @@
 // @vitest-environment node
 // src/components/FinalScore.test.jsx
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect } from 'vitest'
 import React from 'react'
 import { renderToString } from 'react-dom/server'
 import { FinalScore } from './FinalScore'

--- a/src/store/gameStore.js
+++ b/src/store/gameStore.js
@@ -10,7 +10,7 @@ function shuffle(array) {
   return arr
 }
 
-export const useGameStore = create((set, get) => ({
+export const useGameStore = create((set) => ({
   questions: [],
   currentIndex: 0,
   openedPanels: new Set(),


### PR DESCRIPTION
## Summary

- `eslint.config.js` を新規追加（flat config形式）
- `package.json` に `"lint": "eslint src"` スクリプトを追加
- 既存コードのlintエラーを修正

## 変更詳細

### eslint.config.js
- `@eslint/js` recommended ルールを適用
- `eslint-plugin-react-hooks` / `eslint-plugin-react-refresh` を設定
- テストファイル用に vitest globals（`describe`, `it`, `expect`, `vi` 等）を定義
- **注意:** `eslint-plugin-react` v7 は eslint v10 で削除された内部API（`context.getFilename()`）を使用しているため、今回の設定からは除外。react-hooks / react-refresh の2プラグインのみ使用。

### lintエラー修正（3件）
- `Choices.test.jsx` / `FinalScore.test.jsx`: 未使用の `vi` import を削除
- `gameStore.js`: zustand `create()` の未使用パラメータ `get` を削除

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npm run test:run` — 24件すべてパス

https://claude.ai/code/session_01769nWAQxvDo4nrrPEMUccx

---
_Generated by [Claude Code](https://claude.ai/code/session_01769nWAQxvDo4nrrPEMUccx)_