### PR TITLE
chore: add CI workflow to gate PRs to main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,32 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Test
+        run: npm run test:run
+
+      - name: Build
+        run: npm run build


### PR DESCRIPTION
## 概要

main へのPRで `npm ci` / lint / test / build を自動チェックするCIワークフローを追加。

## 追加ファイル

`.github/workflows/ci.yml` — `pull_request` イベント（対象: main）で以下を順番に実行:

1. `npm ci` — 依存関係インストール
2. `npm run lint` — ESLintチェック
3. `npm run test:run` — Vitestテスト
4. `npm run build` — ビルド確認

## マージブロックの有効化（手動設定が必要）

ワークフローを追加するだけでは「CIが落ちていてもマージできる」状態のままです。**マージをブロックするには GitHub の branch protection rule を設定してください。**

Settings → Branches → Add branch protection rule:
- Branch name pattern: `main`
- ✅ **Require status checks to pass before merging**
  - 検索して `ci` を追加
- ✅ **Require branches to be up to date before merging**（推奨）

https://claude.ai/code/session_01769nWAQxvDo4nrrPEMUccx

---
_Generated by [Claude Code](https://claude.ai/code/session_01769nWAQxvDo4nrrPEMUccx)_