### PR TITLE
fix: 選択肢・回答から系列番号を削除し、ひらがなのみに変更

### DIFF
--- a/src/data/questions.json
+++ b/src/data/questions.json
@@ -2,31 +2,31 @@
   {
     "id": 1,
     "imagePath": "/train-photo-quiz/images/e5_hayabusa.jpg",
-    "answer": "E5系はやぶさ",
-    "choices": ["E5系はやぶさ", "E6系こまち", "N700S のぞみ"]
+    "answer": "はやぶさ",
+    "choices": ["はやぶさ", "こまち", "のぞみ"]
   },
   {
     "id": 2,
     "imagePath": "/train-photo-quiz/images/e6_komachi.jpg",
-    "answer": "E6系こまち",
-    "choices": ["E5系はやぶさ", "E6系こまち", "700系ひかり"]
+    "answer": "こまち",
+    "choices": ["はやぶさ", "こまち", "ひかり"]
   },
   {
     "id": 3,
     "imagePath": "/train-photo-quiz/images/n700s_nozomi.jpg",
-    "answer": "N700S のぞみ",
-    "choices": ["N700S のぞみ", "500系のぞみ", "E6系こまち"]
+    "answer": "のぞみ",
+    "choices": ["のぞみ", "つばさ", "こまち"]
   },
   {
     "id": 4,
     "imagePath": "/train-photo-quiz/images/e7_kagayaki.jpg",
-    "answer": "E7系かがやき",
-    "choices": ["E7系かがやき", "N700S のぞみ", "E5系はやぶさ"]
+    "answer": "かがやき",
+    "choices": ["かがやき", "のぞみ", "はやぶさ"]
   },
   {
     "id": 5,
     "imagePath": "/train-photo-quiz/images/500_kodama.jpg",
-    "answer": "500系こだま",
-    "choices": ["E6系こまち", "700系ひかり", "500系こだま"]
+    "answer": "こだま",
+    "choices": ["こまち", "ひかり", "こだま"]
   }
 ]


### PR DESCRIPTION
3歳のひらがな学習用途で、英数字の系列番号（E5系、N700Sなど）を
手がかりに回答できないよう、ひらがなの列車名のみに統一した。
「500系のぞみ」は「のぞみ」との重複を避けるため「つばさ」に差し替え。

Closes #16

https://claude.ai/code/session_01V1MkmMU28GceZoEit1PtWP