### PR TITLE
選択肢の文字サイズを 1rem → 1.15rem に拡大

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -117,7 +117,7 @@ body {
   color: var(--text-color);
   border: 2px solid #334155;
   border-radius: var(--border-radius);
-  font-size: 1rem;
+  font-size: 1.15rem;
   cursor: pointer;
   text-align: left;
   transition: background 0.15s, border-color 0.15s;


### PR DESCRIPTION
## 変更内容

`.choice-btn` の `font-size` を `1rem` から `1.15rem` に拡大し、選択肢の視認性を向上させました。

## 変更箇所

- `src/App.css`: `.choice-btn` の `font-size: 1rem` → `font-size: 1.15rem`

Closes #20

---
_Generated by [Claude Code](https://claude.ai/code/session_017AZptZCtSfkF9PPfF5kjVj)_